### PR TITLE
Fix exception and update composer requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,8 @@
     },
     "minimum-stability": "dev",
     "require": {
-        "yiisoft/yii2": ">=2.0.4",
-        "johnitvn/yii2-ajaxcrud": ">=2.0.0"
+        "yiisoft/yii2": "~2.0",
+        "johnitvn/yii2-ajaxcrud": "~2.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/models/AssignmentSearch.php
+++ b/src/models/AssignmentSearch.php
@@ -71,7 +71,7 @@ class AssignmentSearch extends \yii\base\Model {
             return $dataProvider;
         }
         
-        $query->andFilterWhere([$this->usersModule->userModelIdField => $this->id]);
+        $query->andFilterWhere([$this->rbacModule->userModelIdField => $this->id]);
         $query->andFilterWhere(['like', $this->rbacModule->userModelLoginField, $this->login]);
 
         return $dataProvider;


### PR DESCRIPTION
- Fix exception 
Trying to search assignments by user name, make `yii` throw exception "Unknown module userModule". Problem is what library is trying to use undefined property.
- Update composer requirements
Just cause `composer install` fail with errors